### PR TITLE
Fix spending bug

### DIFF
--- a/clean-notebooks.sh
+++ b/clean-notebooks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# A Shell Script To Remove output data from Jupyter Notebooks
+# This should be manually run before doing any git commits
+#
+# I had attempted to automate this process using filters and git configs
+# described here: 
+# https://zhauniarovich.com/post/2020/2020-10-clearing-jupyter-output-p3/
+#
+# This ran the clean, but any notebooks pushed to the remote were zero bytes
+# For now resorting to the manual method
+
+echo "Removing output from all notebooks cells..."
+jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace *.ipynb

--- a/predict_future_spending.py
+++ b/predict_future_spending.py
@@ -30,9 +30,9 @@ for col in df.columns:
     year = int(col.split(' ', 1)[0])
     if year < ec.IGNORE_YEARS_BEFORE or year == ec.CURRENT_YEAR:
         del df[col]
-    if year < minyr:
+    elif year < minyr:
         minyr = year
-    if year > maxyr:
+    elif year > maxyr:
         maxyr = year
 
 # Create a new column with the average annual spending by group

--- a/visualization_methods.py
+++ b/visualization_methods.py
@@ -21,7 +21,6 @@ def visualize_expenses_by_group(year, year_data, colors, out_file='', spending=T
     '''
     #Build a legend for a Pie Chart that includes the Spending Category and the Amount
     legend_label = []
-    expenses_for_year = year_data.sum()
     for idx in year_data.index:
         if year_data.loc[idx] <= 0:
             # Remove categories with "negative spending"
@@ -31,7 +30,8 @@ def visualize_expenses_by_group(year, year_data, colors, out_file='', spending=T
         else:
             # Otherwise add the group name and amount to the legend
             legend_label.append(idx + ': ${:,.2f}'.format(year_data.loc[idx]))
-            
+    expenses_for_year = year_data.sum()
+    
     # Plot the chart
     if spending:
         title = str(year) + ' Spending: '+ '${:,.2f}'.format(expenses_for_year)


### PR DESCRIPTION
Fixed bug that underestimates annual spending by including categories that generated income in the sum of spending.
Fixed bug that determines the min and max year to generate graphs for.
Added a tool to remove (potentially private) output data from jupyter notebooks